### PR TITLE
Merge ported posts into v4

### DIFF
--- a/content/posts/2025-03-28-fragmented-learning-no-more.md
+++ b/content/posts/2025-03-28-fragmented-learning-no-more.md
@@ -1,0 +1,34 @@
+---
+title: Fragmented learning, no more
+date: 2025-03-28
+tags:
+  - essay
+  - post
+aliases: [uts-0167]
+source: "https://utensil.github.io/forest/uts-0167/"
+external: "https://utensil.bearblog.dev/frag/"
+---
+
+Well, at least I hope so, for 2025.
+
+I started keeping a [[uts-0018]] on math and tech since September 2024.
+
+Before that, I was working on [a series of math notes](uts-000U), in a Zen mode, for months. I annotated PDFs in Margin Note 4, and forged definitions, diagrams into [Forester](https://www.forester-notes.org/) trees which are bi-directionally linked notes that can be rendered into beautiful web pages and LaTeX PDFs, until I'm satisfied. During that time, I didn't read news, unrelated books, and solely focused on the books and papers needed for polishing the notes. I held my breath until one note reached a certain stage, so I might move on to a next note.
+
+It was a mental paradise.
+
+Then came the learning diary idea. Since September, constant context switch had dominated me at work. My attention for learning, had inevitably become fragmented. I started to check out interesting stuff from social media, still about math and tech, they are indeed potential elements of what I might want to work on. So I wished to log these readings or just findings daily, so they are not lost in time.
+
+The habit was well-kept, to the end of 2024, even when the load at work had become unbearably distracting and exhausting. The breadcrumbs would be a gold mine for future me.
+
+But it was a disaster to the mental state of my mind.
+
+During that time, I managed to go back to a few open-source projects that I was working on. Most of them have almost no users, but I still feel the obligation to keep them up to date. Usually I just had little time for each of them, so after some chores, I ran out of time and energy for new features, and moved on to chores for a next project. This partially reflected my mental state caused by my fragmented learning.
+
+The world had become an endless curiosity for me, the potential to work on a new project inspired by an element just learned about, was dazzling.
+
+When I stood at the beginning of 2025, I realized that I'm almost fruitless in 2024. I didn't finish the notes before September, although they are nice in their partially completed form. I didn't create anything in a whole after September. I enjoyed the reward of the journey, but came to the end empty-handed.
+
+I no longer log my learning daily in 2025 due to various reasons. My work and life still consume a lot of my time at the beginning of a year, like always. I still log them, but almost just weekly.
+
+April is coming, I would hope to reach a similar Zen mode like the better half of last year. Hence, this post is poured out of me.

--- a/content/posts/2025-04-07-4-bugs-caught-me-off-guard.md
+++ b/content/posts/2025-04-07-4-bugs-caught-me-off-guard.md
@@ -1,0 +1,108 @@
+---
+title: 4 bugs caught me off guard recently
+date: 2025-04-07
+tags:
+  - math
+  - post
+aliases: [uts-016A]
+source: "https://utensil.github.io/forest/uts-016A/"
+external: "https://utensil.bearblog.dev/bugs/"
+---
+
+And it's non-trivial to hunt their families down.
+
+But yeah, that's pretty much my job description, that is, to set up mechanisms to eliminate similar problems from all systems in future.
+
+They are from different kind of systems and varying technical stacks, so it would be interesting to pin these specimens down for a display.
+
+How to hunt their families down are left as exercises for the readers.
+
+## Legacy configuration removal
+
+The system in question is a proxy server that routes requests to different backends that are responsible for communicating with different third-party APIs. Two keys in the request are used to determine the backend: `party` and `service`, which indicate *who* does *what*, respectively. For the same pair of these keys, even if there is only one type of backend, there could be multiple instances in different availability zones (AZs) and regions.
+
+There is a subsystem (let's call it the "Switch") to route requests based on the health of these instances. It's vital for the switch to always work, so the requests won't go to a bad instance that is already unresponsive.
+
+The Switch will reuse the *static* configurations of the proxy that lists combinations of `party` and `service`, along with *dynamic* instance information. The static and dynamic information as a whole is written to a cache, whenever an arbiter detects unhealthy instances. The proxy will use the cache to change its routing dynamically.
+
+There was a special party (let's call it "Bob") that requires 2 steps/services (namely "Pre" and "Main") to complete what other parties can do in 1 step ("Main"). These 2 steps are stateful in the sense that if an intance can't do "Main", requests should not be routed to "Pre" either.
+
+So when the Switch reads the blob from the cache, a special check is in place to ensure "Bob" & "Pre" are in the combination list, if they are not, the switch will reject to read, and report an error as a monitoring metric which didn't set up a proper alerting threshold for sudden increase in error rate, because it's an error that never happened before, and is missed when SREs setting up the thresholds for important metrics.
+
+10 years passed by, and "Bob" can also do it in one step, "Main". There are also many legacy combinations that are not used anymore. One day it becomes necessary to remove unused combinations, the includes the combination "Bob" & "Pre".
+
+Bang! The Switch rejects all new writes to the cache for 6 days and no one noticed because no major outage happened, the error rate due to unhealthy instances was low enough to be ignored. The issue is only discovered when the same person is observing the Switch for a different deployment, and it took almost a day to figure out the root cause.
+
+The interesting part? The same person who removed the legacy configuration placed those special checks 10 years ago, the reviewer of the removal also reviewed the check 10 years ago. The check was just an unthoughtful precaution, recalling the check and predicting its ramifications on config removal didn't cross the minds of both of them, even during the initial stage of debugging.
+
+## Too many concurrent slow queries
+
+There is a batch processing system (let's call it the "Sink") that loads different kinds of data from asynchronous nodes of production database clusters, according the configured rules about data source, conditions, how to process etc. There are many rate limits in place to prevent the system from overwhelming the database clusters, such as limiting the concurrent number of tasks, and the threshold of the number of concurrent queries on the same database node. It's also an assumption that the asynchronous nodes are not used for user-facing online queries but other batch processing systems.
+
+The rate limits gradually converged to a balance that maximizes the throughput without overwhelming the nodes even during stress tests of high data volume.
+
+There is also a separate monitor metric that tracks slow queries over a certain threshold, and the threshold was also converging, so SREs could focus on the top issues.
+
+One day, many different databases nodes were reporting high load, only for a few seconds each, but continuously affecting an online service that happens to be using asynchronous nodes, as the service is considered less time-sensitive thus tolerable to the delay that asynchronous nodes might have. SREs and DBAs are confused for quite a while, until a technical lead who guessed it might be caused by the batch processing system Sink, which turned out to be true.
+
+The developers of Sink were also confused, as the concurrent queries on the same node, and the slow queries were both within the limits.
+
+The truth did come out in the end. There was 2 tasks configured in Sink, which will be broken down into many sub-tasks for different time spans, and subsequently, queries for different shards of the same table across different asynchronous nodes. And there is a bug in the task configuration that caused slow queries, and the bug was copy-pasted to affect both tasks. Both tasks were running slow slow, but the database nodes could handle the load along with online queries, as the concurrent slow queries are well below the CPU cores that the nodes could use.
+
+One that day, both the tasks were requested to be rerun for 2 time spans by the same person who introduced the bug, which caused concurrent slow queries on the same node to exceed the core count, blocking the online queries. But as the queries are rate-limited so they hit different nodes in a rotating manner, each node was only affected for a few seconds, the overall impact could only be observed by SREs monitoring the online services, and DBAs considered the phenomenon as a normal load spike.
+
+The lesson learned? Each piece of measures were working individually, but they could not account for combinations of different issues, namely too many *concurrent* (and) *slow* queries, and only the combination could cause an impactful issue. And the information about different parts of the system (the online service, database nodes, and Sink) were not shared across teams.
+
+## OOM when retiring old worker processes
+
+This story is about an SOA framework written in C++ (let's call it the "Framework") that will spawn many worker processes to handle requests for a service, and when a new version of the service is deployed, it will gracefully retire the old worker processes, and spawn new ones of the new version to handle requests. The framework also integrates a few plugins to extend its functionality, and the plugins have their own lifecycle management, e.g. `init`, and `fini`.
+
+One of these plugins (let's call it "Charlie") will starts an asynchronous thread for each worker process, and signals the termination of the thread in `fini`. It recommends an explicit call to `fini`, but `fini` was considered trivial enough to be also called in the destructor of the plugin. It's a bad practice in the eyes of any C++ expert, but it worked well for a long time, there was also no issue calling `fini` twice, once explicitly and once in the destructor.
+
+Every few ten thousand deployments, there is an OOM ("Out of memory") when retiring the old worker processes, but it will be killed per cgroup thresholds on memory consumptions, so only few requests are impacted overtime, eventually SREs concluded that the OOMs are not isolated events.
+
+It was a nightmare to reproduce the issue without know the cause upfront, and code looked innocent enough in review. Finally enough data were collected on rare reproductions, and the clues pointed to `fini` in the destructor of Charlie, but there is only the signaling in `fini`. Further investigation revealed that the asynchronous thread was sending a heartbeat request which caused the OOM.
+
+During sending the request, there was a call to a method using local const static `std::array` holding some `std::string` initialized by literals. That static variable had been destroyed when the asynchronous thread is still alive, which would be signaled to terminate later in `fini` in the destructor of Charlie. The destructor was doing its thing not too non-trivial, but too late, due to the undefined execution order of destructors.
+
+Why would this cause an OOM? After destruction, the heap memory involved were still valid, as they were not released but reused by the allocator, thus there is no SEGFAULT, but the memory for `size()` of the strings contains garbage value, which happens to be a large number, and the strings were appending to a `std::stringstream` to form the heartbeat request, causing endless memory allocation until the OOM.
+
+The issue became more reproducible after using an allocator (`tcmalloc`) that would retain the heap memory longer after destruction. It would have been caught by various [sanitizers](https://clickhouse.com/blog/rust#sanitizers) if we have integrated them in CI.
+
+## Silently hanging tasks
+
+It's again about the batch processing system Sink. Internally it uses an MQ to queue tasks, so it can retry failed tasks. To prevent aggressive retries, there is a backoff mechanism that will exponentially increase the delay between retries, and the maximum number of retries is also limited.
+
+One day, an incident caused all available zones of the MQ to drop a certain percentage of network packets, causing a stable failure rate of task dispatching. If the retries are performed in a regular rate, the aggregate delay of tasks would not be too long.
+
+Unfortunately, the backoff mechanism backfired, along with other rate-limiting mechanisms, eventually causing all task to hang indefinitely. Again, existing metrics were not able to pinpoint the issue, and the developers took some time to figure out the root cause. But as the incident causing all SREs to be in a all-hands-on-deck mode, the hung were noticed quickly from less sensitive monitoring metrics, resulted in a relatively timely fix.
+
+A more sensitive monitoring metric was deployed to detect hanging tasks, and it caught another issue a few days later, and the issue was handled swiftly before causing actual delay.
+
+The issue was that there was a silly bug that runs `remove()` for every element in a huge array, and overall it would take `O(n^2)` time to finish, it's almost forever for such huge arrays. The removal would only be triggered when certain conditions are met, and the bug of removal was copy-pasted from some other utility package.
+
+The bug should only hang one processes that handled the task, unfortunately, the dispatcher would detect timeout tasks, considered the process as dead, reassign the task to other processes when the task was still occupying the old process which was burying its head deep in the `remove()` calls, missing its own checkpoint for timeout. The re-assignment happened over and over again for each timeout, eventually causing all processes to be busy with the same task, and the `remove()` calls would almost never finish. The world literally stopped for that task.
+
+With early detection of hanging tasks, developers were able to try fixes quickly. It should not be easy to find the root cause, but the developers noticed long pauses between two log entries, and the removal loop was the only code there when they wanted to add some logging between the log entries, thus the obvious bug was immediately identified.
+
+It's really lucky that the first issue that was not too serious helped to deploy the more sensitive monitoring metric, so the second issue, which could be much fatal, was detected and fixed promptly, on the morning of the first day of a national holiday. Task re-assignment were then limited to prevent poluting more processes with a bad task.
+
+## LLM's takeaways
+
+Disclaimer: The above stories are slightly modified from the actual events, and they are mannually written by me, not generated by LLM.
+
+I asked DeepSeek to write some takeaways as I was a bit tired after telling these stories. This is the version I'm happy with:
+
+1. **Legacy safeguards breed hidden traps**
+   Undocumented checks (Bug 1) and copy-pasted code (Bugs 2, 4) linger as systemic debt. Always audit dependencies before removal or reuse.
+
+2. **Test failure *combinations*, not thresholds**
+   Rate limits + slow queries (Bug 2), retries + packet loss (Bug 4): isolated safeguards fail when risks collide. Model interactions, not silos.
+
+3. **Own lifecycle control explicitly**
+   Destructor chaos (Bug 3) and hanging tasks (Bug 4) stem from assuming cleanup. Govern threads, memory, and resources with strict ownership.
+
+4. **Instrument for why, not what**
+   Missing alerts for config errors (Bug 1), slow queries (Bug 2), or hung processes (Bug 4) delay fixes. Metrics must expose root causes, not just symptoms.
+
+**Core**: Systems fail in layers. Anticipate overlap, govern lifecycles ruthlessly, and monitor for causality—not just correlation.

--- a/content/posts/2025-04-29-my-4-screen-2-mac-setup.md
+++ b/content/posts/2025-04-29-my-4-screen-2-mac-setup.md
@@ -1,0 +1,70 @@
+---
+title: My setup with 4 screens and 2 Macs
+date: 2025-04-29
+tags:
+  - tech
+  - notes
+  - draft
+aliases: [uts-016B]
+source: "https://utensil.github.io/forest/uts-016B/"
+---
+
+Recently, a MacBookPro and a Mac Mini, both are M4 Pro, have become my primary productivity tools. Along with them, I have 3 monitors, plus the one comes with MacBookPro, counts as 4 screens in total. On top of that, I have the logi MX Keys keyboard and MX Master 3S suite, and an Apple Magic Trackpad.
+
+It turns out that I need to come up with a productive setup for them.
+
+## TL;DR as an ASCII art
+
+```
+                                              +---------+
+                                              |         |
+  +-----------------+   +-----------------+   |  Tall   |
+  |    Reference    |   |     Primary     |   |         |
+  |    Display      |   |     Display     |   | Display |
+  +-----------------+   +-----------------+   |         |
+                                              |         |
+        +------+           +------------+     +---------+
+        | Mini |           |    MBP     |
+        +------+           +------------+
+                           | [Keyboard] |
+                           |   [Pad]    |
+                           +------------+
+                            [ MX Keys   ]       [MX 3S]
+                              [Pad]
+```
+
+## Screen arrangement
+
+Above the screen of MacBookPro, I have my primary display, which serves as the main workspace for coding, browsing etc. The second display is placed on its left, on the same height, hosting stuff for reference. Both are horizontal and wide.
+
+The third display (I would like to call it the "tall display") is placed on the right, yet vertically, with its middle part aligned with the primary display, it might host IM, PDFs, AI assistants, or any stuff that are tall, including vertically stacked windows that requires less width.
+
+## Mac-display correspondence
+
+Mac Mini is placed under the second display, and it's connected to the first 2 displays, and all of them if desired.
+
+MacBookPro is connected to the tall display, and optionally also to the primary display.
+
+## Keyboard and mouse
+
+I could just use the keyboard and trackpad of MacBookPro, and they can travel to the nearby Mac Mini.
+
+As I have muscle memory that's already used to MacBookPro's keyboard, MX Keys would be a good fit, as the keys are flatter, the key distance is also shorter.
+
+I'm so used to use the trackpad to scroll, zoom, switching between spaces, and move cursor during coding, so that I would either put MX Keys on top of the keyboard of MacBookPro so I can reach its trackpad effortlessly, or I would just MX Keys and the Magic Trackpad beneath it, with the same relative location like the MacBookPro's keyboard and trackpad.
+
+When I work with diagrams, slides, or UIs that require meticulous mouse control, I would use the MX Master 3S mouse. Its side wheel is configured to send `Ctrl+Left` and `Ctrl+Right`, and side buttons are configured to send `Ctrl+Up` and `Ctrl+Down`, both serving space switching.
+
+The logi keyboard and mouse supports switch between 3 devices, so I can switch between 2 Macs. Unfortunately, one doesn't follow the other to switch, so I would rely on Mac's native support for keyboard and mouse sharing, and it goes like `2->1->MacBookPro->Tall`, so there is minimal extra travel between 1 and tall.
+
+One might noticed that such a setup is highly redundant, but this provides me with maximum flexibility and productivity:
+
+- In coding mode, I could have both hands on the keyboard, with the left hand sometimes on the trackpad
+- In browing mode, my left hand is on the trackpad, and the right hand is on the mouse
+- In diagramming mode, both hands are also on the keyboard, with the right hand sometimes on the mouse
+
+## Thunderbolt bridge
+
+I also have a Thunderbolt bridge, by connecting 2 Macs with a Thunderbolt cable, and following [this guide](https://support.apple.com/guide/mac-help/ip-thunderbolt-connect-mac-computers-mchld53dd2f5/mac). This would create a secure and fast connection between them for file transfer, screen sharing, distributed AI inference etc.
+
+Such a bridge could also be used in MX Flow, but it has certain delay each time the cursor moves between the 2 Macs, so I didn't use it.

--- a/content/posts/2025-05-16-whats-next-for-llms.md
+++ b/content/posts/2025-05-16-whats-next-for-llms.md
@@ -1,0 +1,43 @@
+---
+title: What's next for LLMs?
+date: 2025-05-16
+tags:
+  - tech
+  - notes
+  - draft
+  - essay
+  - post
+aliases: [uts-016C]
+source: "https://utensil.github.io/forest/uts-016C/"
+external: "https://utensil.bearblog.dev/llm-next/"
+---
+
+This is no way a professional prediction, just summarizing some ideas popped into my head in a recent discussion with friends. Read this with a grain of salt.
+
+Reasoning, agent, and multimodality are top 3 research topics for LLMs, as far as I can tell. And for me, there is always the topic of efficiency or scalability. And of course, beyond that, world models, and intelligent robotics.
+
+Verifiable reinforcement learning boosted the reasoning performance as explored by DeepSeek and others, but it requires much more output tokens, to a factor of almost 10. That would be 10x inference compute, and to solve the same problem in the same time, you would need another 10x compute to achieve that. Such a 100x compute demand, is not desirable.
+
+I was wrong in 2023, about the inefficient inference of LLMs. I didn't like the quadratic scaling of the attention mechanism, but it turns out that there are more ways to work around the bottleneck than seeking linear attention such as RWKV and other alternatives. Inference time scaling, and MoE are both game changers.
+
+So I would expect myself to be wrong again about the cost of reasoning. And there are preliminary researches showing that reasoning [is already inside](https://transformer-circuits.pub/2025/attribution-graphs/biology.html) and [can be further trained into](https://huggingface.co/papers/2505.10554) the LLMs.
+
+That is, reasoning should not be happening at the output layer, but intermediate layers. Writing down the reasoning process, should merely serve as a memory of explored paths, to keep things on track, or materialize the box to think out of.
+
+The waste is not just on the input side, there are significant waste of input tokens by prompts that are not part of the instruction nor the context, but guidance. These guidances should not just be cached, but "compiled", in a more efficient and controllable manner, while remaining the interpretability.
+
+Prompt engineering and reasoning by output tokens are two sides of the same coin: we are reaching better results in an interpretable manner, but much more expensive than it should be, and it would become obvious once we find the right principle. Of course, history relies on such detours to get back on track.
+
+Agent is another layer of waste, on top of individual inferences. Agents fall into fruitless planning and exploration, failing to snap out of the infinite loop, by acquiring the extra information or triggering the extra side effects. Their interactions with tools (e.g., MCP), agents (e.g., A2A), and humans (e.g., A2H) are all inefficient due to using natural language as the intermediate representation.
+
+Imagine an alien species with a far more efficient language, like the one depicted in *Arrival*. Such a language could express complex concepts like tool invocation with parameters using just a single token - or perhaps a single multimodal token combining multiple meanings.
+
+There should be special dense tokens, to represent tools or even ways to think (e.g., the MCP for "Sequential Thinking"). And why should a token just be an embedding of a high dimensional vector? Why isn't it a curve, a hypersurface, or a manifold?
+
+Take some time to think about this, while showing the visualization of [the Biology of a Large Language Model](https://transformer-circuits.pub/2025/attribution-graphs/biology.html) on the screen.
+
+I believe using modularity other than human perceptions, as the intermediate representation, is the key to the next breakthrough. They would also represent the world model better.
+
+At the end of the day, it all comes down to human-level efficiency to reach human-level intelligence. And the efficiency will come from using the right principle, which will also result in better performance.
+
+And all of reasoning, agent, multimodality, efficiency, world model, and robotics, are all covered by this one integrated solution.

--- a/content/posts/2025-05-25-some-hf-papers-worth-skimming.md
+++ b/content/posts/2025-05-25-some-hf-papers-worth-skimming.md
@@ -1,0 +1,131 @@
+---
+title: some HF papers worth skimming
+date: 2025-05-25
+tag: draft
+aliases: [uts-016E]
+source: "https://utensil.github.io/forest/uts-016E/"
+---
+
+- multimodal, diffusion
+    - [Scaling Diffusion Transformers Efficiently via μP](https://huggingface.co/papers/2505.15270)
+        - establish μP as a principled and efficient scaling strategy for diffusion Transformers
+        - with appendix on Theoretical Background of μP
+    - [Neurosymbolic Diffusion Models](https://huggingface.co/papers/2505.13138)
+        - the first method to integrate masked diffusion models as the neural network extractor in neurosymbolic predictors
+        - with a very long appendix on math background
+    - [Diffusion vs. Autoregressive Language Models: A Text Embedding Perspective](https://huggingface.co/papers/2505.15045)
+        - propose adopting diffusion language models for text embeddings, motivated by their inherent bidirectional architecture and recent success in matching or surpassing LLMs especially on reasoning tasks
+        - focus on [Dream 7b: Introducing dream 7b, the most powerful open diffusion large language model to date](https://hkunlp.github.io/blog/2025/dream/)
+            - consistently outperforms existing diffusion language models by a large margin
+            - matches or exceeds top-tier Autoregressive (AR) language models of similar size on the general, math, and coding abilities
+            - demonstrates strong planning ability and inference flexibility that naturally benefits from the diffusion modeling
+            - virtually all leading LLMs relying on this same sequential left-to-right architecture
+            - Discrete diffusion models (DMs) have gained attention as a promising alternative for sequence generation since their introduction to the text domain, which dynamically refine the full sequence in parallel starting from a fully noised state
+    - [MMaDA: Multimodal Large Diffusion Language Models](https://huggingface.co/papers/2505.15809)
+        - unified diffusion architecture
+        - superior performance across diverse domains such as textual reasoning, multimodal understanding, and text-to-image generation
+        - rich and impressive examples
+        - with appendix on Preliminaries of Discrete Diffusion, PPO and GRPO
+    - [LaViDa: A Large Diffusion Language Model for Multimodal Understanding](https://huggingface.co/papers/2505.16839)
+        - Large Vision-Language Diffusion Model with Masking
+        - follows a similar design to common AR VLMs like LLaVa
+    - [GRIT: Teaching MLLMs to Think with Images](https://huggingface.co/papers/2505.15879)
+        - generate visually grounded reasoning chains by interleaving natural language with explicit bounding box coordinates referencing relevant image regions
+    - [Dimple: Discrete Diffusion Multimodal Large Language Model with Parallel Decoding](https://huggingface.co/papers/2505.16990)
+        - trained using a novel two-phase paradigm–Autoregressive-then-Diffusion
+    - [dKV-Cache: The Cache for Diffusion Language Models](https://huggingface.co/papers/2505.15781)
+        - diffusion language models have long been constrained by slow inference
+        - motivated by the observation that different tokens have distinct representation dynamics throughout the diffusion process
+        - propose a delayed and conditioned caching strategy for key and value states
+    - [Understanding Generative AI Capabilities in Everyday Image Editing Tasks](https://huggingface.co/papers/2505.16181)
+        - analyzing 83k requests with their associated 305k edits from the recent 12 years on the `/r/PhotoshopRequest` Reddit community
+        - new dataset: [PSR](https://huggingface.co/datasets/PSRDataset/PSR)
+    - [Hunyuan-Game: Industrial-grade Intelligent Game Creation Model](https://huggingface.co/papers/2505.14135)
+        - lots of examples of game creation
+- efficiency
+    - [Scaling Law for Quantization-Aware Training](https://huggingface.co/papers/2505.14302)
+        - a comprehensive scaling law for 4-bit QAT of LLMs, integrating model size, training dataset size, and quantization granularity
+        - previous methods do not account for quantization granularity G
+        - weight and activation quantization errors tend to contribute almost equally to the total error
+    - [Fine-tuning Quantized Neural Networks with Zeroth-order Optimization](https://huggingface.co/papers/2505.13430)
+        - push the limits of memory-efficient training by minimizing memory usage on model weights, gradients, and optimizer states, within a unified framework
+        - perturbs the continuous quantization scale for gradient estimation and uses a directional derivative clipping method to stabilize training
+        - Zeroth-order optimization (ZO) methods are often used in cases where gradients and higher-order derivatives of the objective cannot be directly computed or are unreliable
+        - successfully fine-tune Stable Diffusion 3.5 Large quantized by BitsAndBytes on stylized images using a single Nvidia RTX 4090 24GB GPU
+    - [A Token is Worth over 1,000 Tokens: Efficient Knowledge Distillation through Low-Rank Clone](https://huggingface.co/papers/2505.12781)
+        - trains a set of low-rank projection matrices that jointly enable soft pruning by compressing teacher weights, and activation clone by aligning student activations, including FFN signals, with those of the teacher
+        - remarkable distillation efficiency, achieving superior performance with more than 1000× fewer training tokens
+        - LRC w/o FFN produces a substantial performance degradation that persists throughout training, further confirming the critical importance of FFN activations
+        - LRC’s projection-based alignment is not only sufficient for effective knowledge transfer but also more efficient and stable
+- agents, reasoning, RL
+    - [NovelSeek: When Agent Becomes the Scientist -- Building Closed-Loop System from Hypothesis to Verification](https://huggingface.co/papers/2505.16938)
+    - [Reinforcement Learning Finetunes Small Subnetworks in Large Language Models](https://huggingface.co/papers/2505.11711)
+    - [Tool-Star: Empowering LLM-Brained Multi-Tool Reasoner via Reinforcement Learning](https://huggingface.co/papers/2505.16410)
+    - [AceReason-Nemotron: Advancing Math and Code Reasoning through Reinforcement Learning](https://huggingface.co/papers/2505.16400)
+    - [Training-Free Reasoning and Reflection in MLLMs](https://huggingface.co/papers/2505.16151)
+    - [Date Fragments: A Hidden Bottleneck of Tokenization for Temporal Reasoning](https://huggingface.co/papers/2505.16088)
+    - [RLVR-World: Training World Models with Reinforcement Learning](https://huggingface.co/papers/2505.13934)
+    - [SPhyR: Spatial-Physical Reasoning Benchmark on Material Distribution](https://huggingface.co/papers/2505.16048)
+    - [Risk-Averse Reinforcement Learning with Itakura-Saito Loss](https://huggingface.co/papers/2505.16925)
+- safety
+    - [Phare: A Safety Probe for Large Language Models](https://huggingface.co/papers/2505.11365)
+    - [Audio Jailbreak: An Open Comprehensive Benchmark for Jailbreaking Large Audio-Language Models](https://huggingface.co/papers/2505.15406)
+    - [Are Vision-Language Models Safe in the Wild? A Meme-Based Benchmark Study](https://huggingface.co/papers/2505.15389)
+- application
+    - [Steering Large Language Models for Machine Translation Personalization](https://huggingface.co/papers/2505.16612)
+    - [This Time is Different: An Observability Perspective on Time Series Foundation Models](https://huggingface.co/papers/2505.14766)
+    - [Prior Prompt Engineering for Reinforcement Fine-Tuning](https://huggingface.co/papers/2505.14157)
+    - [Using Large Language Models for Commit Message Generation: A Preliminary Study](https://arxiv.org/abs/2401.05926)
+    - [The Distracting Effect: Understanding Irrelevant Passages in RAG](https://huggingface.co/papers/2505.06914)
+- more
+    - [Distilling LLM Agent into Small Models with Retrieval and Code Tools](https://huggingface.co/papers/2505.17612)
+    - [CLEVER: A Curated Benchmark for Formally Verified Code Generation](https://arxiv.org/abs/2505.13938)
+    - [DiSA: Diffusion Step Annealing in Autoregressive Image Generation](https://huggingface.co/papers/2505.20297)
+    - [Capability-Based Scaling Laws for LLM Red-Teaming](https://huggingface.co/papers/2505.20162)
+    - [FinTagging: An LLM-ready Benchmark for Extracting and Structuring Financial Information](https://huggingface.co/papers/2505.20650)
+    - [GSO: Challenging Software Optimization Tasks for Evaluating SWE-Agents](https://arxiv.org/abs/2505.23671)
+    - watch [The 3D Gaussian Splatting Adventure: Past, Present, Future](https://www.youtube.com/watch?v=DjOqkVIlEGY)
+    - [DCM: Dual-Expert Consistency Model for Efficient and High-Quality Video Generation](http://arxiv.org/pdf/2506.03123v1)
+    - [GUI-Actor: Coordinate-Free Visual Grounding for GUI Agents](http://arxiv.org/pdf/2506.03143v1)
+    - [Agentic Neural Networks: Self-Evolving Multi-Agent Systems via Textual Backpropagation](http://arxiv.org/pdf/2506.09046v1)
+    - [Large Language Models Often Know When They Are Being Evaluated](https://arxiv.org/abs/2505.23836)
+    - [Tiny-diffusion: A minimal implementation of probabilistic diffusion models](https://github.com/tanelp/tiny-diffusion)
+    - [AgentDistill: Training-Free Agent Distillation with Generalizable MCP Boxes](http://arxiv.org/pdf/2506.14728v1)
+    - [Time Series Forecasting with Graph Transformers](https://kumo.ai/research/time-series-forecasting/)
+    - [The Effect of State Representation on LLM Agent Behavior in Dynamic Routing Games](http://arxiv.org/pdf/2506.15624v1)
+    - [Compiling LLMs into a MegaKernel: A path to low-latency inference](https://zhihaojia.medium.com/compiling-llms-into-a-megakernel-a-path-to-low-latency-inference-cf7840913c17)
+    - [Magenta RealTime: An Open-Weights Live Music Model](https://simonwillison.net/2025/Jun/20/magenta-realtime/#atom-everything)
+    - [Audit & Repair: An Agentic Framework for Consistent Story Visualization in Text-to-Image Diffusion Models](http://arxiv.org/pdf/2506.18900v1)
+    - [Let Your Video Listen to Your Music!](http://arxiv.org/pdf/2506.18881v1)
+    - [Vision as a Dialect: Unifying Visual Understanding and Generation via Text-Aligned Representations](http://arxiv.org/pdf/2506.18898v1)
+    - [Bridging Cinematic Principles and Generative AI for Automated Film Generation](https://arxiv.org/abs/2506.18899)
+    - [Show HN: PILF, The ultimate solution to catastrophic oblivion on AI models](https://github.com/dmf-archive/PILF)
+    - [Qwen VLo: From “Understanding” the World to “Depicting” It](https://qwenlm.github.io/blog/qwen-vlo/)
+    - [WorldVLA: Towards Autoregressive Action World Model](https://arxiv.org/abs/2506.21539) ([on HN](https://news.ycombinator.com/item?id=44417725))
+    - [Small language models are the future of agentic AI](https://arxiv.org/abs/2506.02153) ([on HN](https://news.ycombinator.com/item?id=44430311))
+    - [Overclocking LLM Reasoning: Monitoring and Controlling LLM Thinking Path Lengths](https://royeisen.github.io/OverclockingLLMReasoning-paper/) ([on HN](https://news.ycombinator.com/item?id=44480400))
+    - [Reinforcement Learning from Human Feedback (RLHF) in Notebooks](https://github.com/ash80/RLHF_in_notebooks)
+    - [LLMs should not replace therapists](https://arxiv.org/abs/2504.18412) ([on HN](https://news.ycombinator.com/item?id=44484207))
+    - [Mercury: Ultra-fast language models based on diffusion](https://arxiv.org/abs/2506.17298) ([on HN](https://news.ycombinator.com/item?id=44489690))
+    - [Biomni: A General-Purpose Biomedical AI Agent](https://github.com/snap-stanford/Biomni) ([on HN](https://news.ycombinator.com/item?id=44513843))
+    - [Distributed AI Agents for Cognitive Underwater Robot Autonomy](http://arxiv.org/pdf/2507.23735v1)
+    - [GEPA: Reflective prompt evolution can outperform reinforcement learning](https://arxiviq.substack.com/p/gepa-reflective-prompt-evolution) ([on HN](https://news.ycombinator.com/item?id=44744331))
+    - [Hijacking multi-agent systems in your PajaMAS](https://blog.trailofbits.com/2025/07/31/hijacking-multi-agent-systems-in-your-pajamas/)
+    - [Core Safety Values for Provably Corrigible Agents](http://arxiv.org/pdf/2507.20964v1)
+    - [Flow Matching Policy Gradients](http://arxiv.org/pdf/2507.21053v1)
+    - [Fine-tuned small LLMs can beat large ones with programmatic data curation](https://www.tensorzero.com/blog/fine-tuned-small-llms-can-beat-large-ones-at-5-30x-lower-cost-with-programmatic-data-curation/) ([on HN](https://news.ycombinator.com/item?id=44787611))
+        - the chosen task is considered not challenging
+    - [Persona vectors: Monitoring and controlling character traits in language models](https://www.anthropic.com/research/persona-vectors) ([on HN](https://news.ycombinator.com/item?id=44777760))
+    - [Qwen-Image: Crafting with native text rendering](https://qwenlm.github.io/blog/qwen-image/) ([on HN](https://news.ycombinator.com/item?id=44787631))
+    - [Exploring Autonomous Agents: A Closer Look at Why They Fail When...](http://arxiv.org/abs/2508.13143v1)
+    - [Kimina-Prover: Applying Test-time RL Search on Large Formal Reasoning Models](https://huggingface.co/blog/AI-MO/kimina-prover)
+    - [Emergent Misalignment: Narrow finetuning can produce broadly misaligned LLMs](https://arxiv.org/abs/2502.17424) ([on HN](https://news.ycombinator.com/item?id=44554865))
+    - [Context Rot: How Increasing Input Tokens Impacts LLM Performance](https://research.trychroma.com/context-rot) ([on HN](https://news.ycombinator.com/item?id=44564248)) ([on lobste.rs](https://lobste.rs/s/untq6g))
+    - [All AI models might be the same](https://blog.jxmo.io/p/there-is-only-one-model) ([on HN](https://news.ycombinator.com/item?id=44595811))
+    - [LLM Economist: Large Population Models and Mechanism Design in Multi-Agent Generative Simulacra](http://arxiv.org/pdf/2507.15815v1)
+    - [Subliminal learning: Models transmit behaviors via hidden signals in data](https://alignment.anthropic.com/2025/subliminal-learning/) ([on HN](https://news.ycombinator.com/item?id=44650840))
+        - [Simon Willison | Subliminal Learning: Language Models Transmit Behavioral Traits via Hidden Signals in Data](https://simonwillison.net/2025/Jul/22/subliminal-learning/)
+    - [Flow Matching Meets Biology and Life Science: A Survey](http://arxiv.org/pdf/2507.17731v1)
+    - [Seed-Prover/SeedProver at main · ByteDance-Seed/Seed-Prover](https://github.com/ByteDance-Seed/Seed-Prover/tree/main/SeedProver)
+    - [Transformers Without Normalization](https://arxiv.org/abs/2503.10622) ([on HN](https://news.ycombinator.com/item?id=44671375))
+    - [Embedding-Aware Quantum-Classical SVMs for Scalable Quantum Machine Learning](https://arxiv.org/abs/2508.00024)

--- a/content/posts/2025-06-02-resources-about-rubiks-cube.md
+++ b/content/posts/2025-06-02-resources-about-rubiks-cube.md
@@ -1,0 +1,42 @@
+---
+title: Resources about Rubik's Cube
+date: 2025-06-02
+tags:
+  - tech
+  - notes
+  - draft
+aliases: [uts-016J]
+source: "https://utensil.github.io/forest/uts-016J/"
+---
+
+- speed solving
+    - Roux (a.k.a as bridging)
+        - [Learning the Roux method](http://markfiend.com/roux.html)
+        - [Simple Roux Method of Solving Rubik's Cube](https://www.ekrohn.com/cubing/roux.html)
+        - [Introduction - Roux Tutorial](https://tutorial.rouxers.com/introduction.html)
+            - uses [TwistySim](https://cube.rider.biz/twistysim.html)
+    - ZZ
+        - [Example Solves - Beginner ZZ Tutorial](https://cube.rider.biz/zz.php?v=beginner&p=eg)
+- notation
+    - [Rubik's cube notation by Sebastiano Tronto](https://sebastiano.tronto.net/speedcubing/notation/)
+    - [3x3x3 notation](https://www.speedsolving.com/wiki/index.php/3x3x3_notation)
+        - which clarifies naming of `E`, `S`, `r` etc.
+- papers
+    - [The Generalized Rubik’s Cube: Combinatorial Insights Through Group Theory](http://kth.diva-portal.org/smash/record.jsf?pid=diva2:1879474&dswid=3892)
+        - it cites \citef{salkinder2021nxnxn}
+        - has its own notation for nxnxn cubies
+        - works out many details about general nxnxn cubes and their corresponding group theory
+    - [Commutators in the Rubik’s Cube Group](https://www.tandfonline.com/doi/pdf/10.1080/00029890.2023.2263158)
+        - uses notations like `UR`, `FUR` to denote edges and corners, which I prefered
+        - nice diagrams
+        - [demo with Twizzle](https://timothysun.info/commutator.html)
+    - [Generalising the configurations of an N×N×N Rubik’s Cube](https://www.parabola.unsw.edu.au/sites/default/files/2025-01/vol59_no3_3.pdf)
+        - aimed to find an expression for the total number of possible configurations of an N×N×N Rubik’s Cube
+        - uses notations like `ur`, `fur`, `u_1` for 3x3x3 and 4x4x4 cubes
+        - generalize to N×N×N with 3x3x3-style edges and 4x4x4-style corners
+- solving with linear algebra
+    - asked by [this Reddit post](https://www.reddit.com/r/math/comments/3diu8p/is_there_a_way_to_solve_a_rubiks_cube_with_linear/)
+    - [Mathematics of the Rubik’s cube](https://www.permutationpuzzles.org/rubik/webnotes/rubik.pdf) by W. D. Joyner in 1996
+    - [Non-Commutative Gaussian Elimination and Rubik’s Cube](https://drorbn.net/AcademicPensieve/2013-01/NCGE/)
+- [[uts-016I]]
+- [[uts-016H]]

--- a/content/posts/2025-06-12-trying-zigs-self-hosted-x86-backend.md
+++ b/content/posts/2025-06-12-trying-zigs-self-hosted-x86-backend.md
@@ -1,0 +1,263 @@
+---
+title: Trying Zig's self-hosted x86 backend on Apple Silicon
+date: 2025-06-12
+tag: post
+aliases: [uts-016K]
+source: "https://utensil.github.io/forest/uts-016K/"
+external: "https://utensil.bearblog.dev/zig-self-hosted-backend/"
+---
+
+> TL;DR: I used `colima` to run an x86_64 Docker container (Ubuntu) on Apple silicon, to quickly test `zig build` with LLVM backend and with self-hosted backend, because it's both [exciting](https://ziggit.dev/t/can-someone-explain-why-zig-is-moving-away-from-llvm-but-in-simple-way/1226/6) and concerning (for missing all the goodies from LLVM) news.
+
+After [Self-Hosted x86 Backend is Now Default in Debug Mode](https://ziglang.org/devlog/2025/?unique/#2025-06-08) dropped, I immediately wanted to try it out, but I only have an Apple Silicon machine (e.g. Mac Mini M4 Pro).
+
+## Running an x86 container on Apple Silicon
+
+According to [Intel-on-ARM and ARM-on-Intel](https://lima-vm.io/docs/config/multi-arch/), I'm supposed to be able to run x86_64 Zig using `lima` with Apple's native virtualization framework and Rosetta. After some fiddling and [searching](https://github.com/lima-vm/lima/discussions/1043#discussioncomment-3560889), I've realized that I could just use `colima` to run an x86_64 container on an ARM64 VM, which is also backed by `lima`.
+
+OK, let's get started:
+
+First, install `colima` and prepare it properly:
+
+```bash
+# we need `docker` CLI as the client
+which docker || (brew install docker; brew link docker)
+
+# (optional) while we are at it, get `docker-compose` and `kubectl` too
+which docker-compose || brew install docker-compose
+which kubectl || brew install kubectl
+
+# install colima
+which colima || brew install colima
+
+# this is to prevent othere docker daemons from interfering
+docker context use default
+```
+
+Next, let's start colima with Apple's native virtualization framework and rosetta:
+
+```bash
+colima start --vm-type=vz --vz-rosetta
+```
+
+Because I have already used colima before, but without these flags, there is a warning saying that they are ignored, so I have to delete the existing colima VM and start over.
+
+(Warning: the following command will also DELETE all existing images! So I commented out them to prevent accidental execution.)
+
+```bash
+# colima delete
+```
+
+Now, we can pull an x86_64 Docker container with Ubuntu:
+
+```bash
+# asssuming `docker login` has been done already
+docker pull --platform linux/amd64 ubuntu:jammy
+```
+
+and start it (`--rm` means to remove the container after it exits, so we'll lose the changes made inside, remove this option if you want to keep the container):
+
+```bash
+docker run --rm -it --platform linux/amd64 ubuntu:jammy bash
+```
+
+Inside the container, let's confirm that we are indeed running x86_64:
+
+```bash
+uname -m
+```
+
+Cool, I'm seeing `x86_64`!
+
+## Running `zig build`
+
+Now, we can install Zig and try it out:
+
+```bash
+# we need a few basic utils
+apt update
+apt install -y wget xz-utils software-properties-common git
+
+# Download the corresponding Zig version with self-hosted x86 backend
+wget https://ziglang.org/builds/zig-x86_64-linux-0.15.0-dev.769+4d7980645.tar.xz
+tar xvf zig-x86_64-linux-0.15.0-dev.769+4d7980645.tar.xz
+
+# Make it available in PATH
+export PATH=/zig-x86_64-linux-0.15.0-dev.769+4d7980645/:$PATH
+
+# Verify its version and that it runs
+zig version
+# got: 0.15.0-dev.769+4d7980645
+```
+Let's create a simple Zig project to test building it:
+
+```bash
+mkdir projects
+cd projects
+mkdir zig_x86_64
+cd zig_x86_64
+
+zig init
+zig build
+```
+
+Success!
+
+`zig build run` gives
+
+```
+All your codebase are belong to us.
+Run `zig build test` to run the tests.
+```
+
+and `zig build test --summary all` gives:
+
+```
+Build Summary: 5/5 steps succeeded; 3/3 tests passed
+test success
+├─ run test 1 passed 7ms MaxRSS:5M
+│  └─ compile test Debug native cached 68ms MaxRSS:44M
+└─ run test 2 passed 7ms MaxRSS:5M
+   └─ compile test Debug native cached 67ms MaxRSS:44M
+```
+
+## Comparing with and without LLVM
+
+But wait, how do I know it's actually using the self-hosted x86 backend?
+
+Hopefully someone has a better way, I just took the longer way to force Zig to build with and without LLVM.
+
+After reading the [doc](https://ziglang.org/documentation/master/std/#std.Build.addExecutable) and some [searching](https://ziggit.dev/t/pass-build-option-to-a-dependency/4196/7), I figured out that I could expose an extra option to `zig build` in my `build.zig` to set the corresponding flag for the executable, with only 2 edits:
+
+```zig
+    // EDIT 1
+    const use_llvm = b.option(bool, "use_llvm", "Force use llvm or not") orelse false;
+
+    const exe = b.addExecutable(.{
+        .name = "zig_x86_64",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "zig_x86_64", .module = mod },
+            },
+        }),
+        // EDIT 2
+        .use_llvm = use_llvm,
+    });
+```
+
+(Optional) I did the edits by running the following to install a helix editor so I can edit Zig code out-of-the-box:
+
+```bash
+# https://docs.helix-editor.com/package-managers.html#ubuntu-ppa
+add-apt-repository -y ppa:maveonair/helix-editor
+apt install helix
+# then fire up `hx build.zig` and use it mostly like in Vim
+# I also installed zls by
+# cd /tmp
+# wget https://builds.zigtools.org/zls-linux-x86_64-0.15.0-dev.197+48fb941e.tar.xz
+# tar xvf zls-linux-x86_64-0.15.0-dev.197+48fb941e.tar.xz
+# cp -f zls /usr/local/bin/
+# and checked that it works by
+# hx --health zig
+# so I can use `gd` to go to definitions!
+```
+
+Cool, now let's try building with LLVM:
+
+```bash
+rm -rf .zig-cache && time zig build -Duse_llvm=true
+```
+
+```
+real    0m3.068s
+user    0m3.610s
+sys     0m0.363s
+```
+
+Then without (which should be the x86 self-hosted backend):
+
+```bash
+rm -rf .zig-cache && time zig build -Duse_llvm=false
+```
+
+```
+real    0m2.112s
+user    0m2.812s
+sys     0m0.361s
+```
+
+Wow, it's indeed faster without LLVM! I've tested this a few times and getting consistent results. I'll also try this on more complex projects later, but it's so exciting that I just wanted to write a note for this.
+
+### UPDATE 2025-06-15
+
+I further tried using [poop](https://github.com/andrewrk/poop) to get more metrics.
+
+First, get and install `poop`:
+
+```bash
+cd /projects && git clone https://github.com/andrewrk/poop && cd poop && zig build && cp -f zig-out/bin/poop /usr/local/bin/
+```
+
+Then let's run the cold start builds again:
+
+```bash
+cd /projects/zig_x86_64
+
+rm -rf .zig-cache* && poop "zig build -Duse_llvm=true --cache-dir .zig-cache-llvm" "zig build -Duse_llvm=false --cache-dir .zig-cache-nollvm"
+```
+
+Well, that doesn't work due to permission denied. And [`--cap-add PERFMON` or even `--cap-add SYS_ADMIN`](https://stackoverflow.com/questions/44745987/use-perf-inside-a-docker-container-without-privileged/78593324) didn't work. Not even `--privileged`. See [this issue](https://github.com/andrewrk/poop/issues/17#issuecomment-2973619089).
+
+Let's try `hyperfine` instead:
+
+```bash
+apt install -y hyperfine
+```
+
+Taking comments by `mlugg0` on reddit into account, a few factors should be ruled out for a more fair comparison (with C):
+
+1. rule out the build time for `build.zig`;
+2. rule out the overhead of panic handler
+3. squeeze a bit of performance at the cost of [some safety](https://nathancraddock.com/blog/zig-cc-undefined-behavior/) by disabling C sanitization.
+
+1 means to build `build.zig` before the benchmark and after cleaning the cache (observing that `zig build --help`  will build `build.zig` in order to get the options defined in the build script).
+
+2 means to add the following to `main.zig`:
+
+```zig
+/// Don't print a fancy stack trace if there's a panic
+pub const panic = std.debug.no_panic;
+/// Don't print a fancy stack trace if there's a segfault
+pub const std_options: std.Options = .{ .enable_segfault_handler = false };
+```
+
+3 means to pass `.sanitize_c = .off` to `root_module` in `build.zig`.
+
+With
+
+```bash
+hyperfine --prepare "rm -rf .zig-cache* && zig build --help -Duse_llvm=true && zig build --help -Duse_llvm=false" "zig build -Duse_llvm=true" "zig build -Duse_llvm=false"
+```
+
+I got
+
+```
+Benchmark 1: zig build -Duse_llvm=true
+  Time (mean ± σ):      1.392 s ±  0.052 s    [User: 1.287 s, System: 0.126 s]
+  Range (min … max):    1.329 s …  1.473 s    10 runs
+
+Benchmark 2: zig build -Duse_llvm=false
+  Time (mean ± σ):     546.1 ms ±  13.6 ms    [User: 570.1 ms, System: 128.7 ms]
+  Range (min … max):   532.9 ms … 575.9 ms    10 runs
+
+Summary
+  'zig build -Duse_llvm=false' ran
+    2.55 ± 0.11 times faster than 'zig build -Duse_llvm=true'
+```
+
+which is indeed even faster!
+
+discussions on [/r/Zig](https://www.reddit.com/r/Zig/comments/1lb2vq8/trying_zigs_selfhosted_x86_backend_on_apple/), [Bluesky](https://bsky.app/profile/iutensil.bsky.social/post/3lrfd2v3zus2n)

--- a/content/posts/2025-06-15-run-perf-in-colima.md
+++ b/content/posts/2025-06-15-run-perf-in-colima.md
@@ -1,0 +1,85 @@
+---
+title: How to run perf in a colima container
+date: 2025-06-15
+tags:
+  - tech
+  - notes
+  - draft
+aliases: [uts-016L]
+source: "https://utensil.github.io/forest/uts-016L/"
+---
+
+Just to note down that it's not straightforward to get perf working.
+
+Here's what worked finally:
+
+First, the container needs to be started with proper capabilities:
+
+```bash
+docker run --rm -it --platform linux/amd64 --cap-add PERFMON ubuntu:jammy bash
+```
+
+Secondly, some flags need to be set from the VM:
+
+```bash
+# this would start a shell in the VM, outside of containers
+colima ssh
+
+# don't know why, sudo doesn't work, but it works in a root shell
+# -1 or 2 both work
+sudo bash -c 'echo -1 > /proc/sys/kernel/perf_event_paranoid'
+```
+
+Lastly, install perf in the container:
+
+```bash
+apt install -y linux-tools-$(uname -r) linux-cloud-tools-$(uname -r)
+```
+
+Then the following works:
+
+```bash
+perf record -g echo 1
+perf report -g graph,0.5,caller
+```
+
+Note also that you can't pass `"echo 1"` because perf will failed to find a file named "echo 1".
+
+Learned this while working on [[uts-016K]] and before submitting [this issue](https://github.com/andrewrk/poop/issues/17#issuecomment-2973619089) about unable to run `poop` in `colima` containers.
+
+Follow-up:
+
+It's important to check whether certain perf counters actually work:
+
+```
+sleep 10 &
+perf stat -p $! -e "cpu-cycles,instructions,cache-references,cache-misses,branch-misses"
+```
+
+On a machine that supports corresponding counters, it should give something like:
+
+```
+ Performance counter stats for process id '101011':
+
+            511488      cpu-cycles                                                  
+            280194      instructions              #    0.55  insn per cycle         
+             16193      cache-references                                            
+              6161      cache-misses              #   38.047 % of all cache refs    
+              8730      branch-misses                                               
+
+      10.009515156 seconds time elapsed
+```
+
+On an unsupported machine, the output would be like:
+
+```
+ Performance counter stats for process id '552':
+
+   <not supported>      cpu-cycles
+   <not supported>      instructions
+   <not supported>      cache-references
+   <not supported>      cache-misses
+   <not supported>      branch-misses
+
+       6.491105847 seconds time elapsed
+```

--- a/content/posts/2025-07-13-try-some-alternative-browsers.md
+++ b/content/posts/2025-07-13-try-some-alternative-browsers.md
@@ -1,0 +1,28 @@
+---
+title: Try some alternative browsers
+date: 2025-07-13
+tags:
+  - tech
+  - notes
+  - draft
+aliases: [uts-016N]
+source: "https://utensil.github.io/forest/uts-016N/"
+---
+
+I decided to widen my horizon about browsers. After browsing a few subreddits, I have chosen these 3 browsers:
+
+- [Arc](https://arc.net/)
+    - Chromium based
+    - the team has moved on to Dia, an AI browser
+    - but people still miss the UX of Arc, it seems to be one of a kind, so I have to know
+    - unlikely to be open-source
+    - Mac/iOS/Windows, no Linux
+- [Orion](https://kagi.com/orion/)
+    - WebKit based, this engine is the best hope for degoogle
+    - will be open-source
+    - not mature yetA
+    - Mac/iOS, Linux WIP, no Windows/Android
+- [Floorp](https://floorp.app/)
+    - Firefox based
+    - open-source
+    - Mac/Windows/Linux, no mobile

--- a/content/posts/2025-07-18-distributing-my-binaries.md
+++ b/content/posts/2025-07-18-distributing-my-binaries.md
@@ -1,0 +1,21 @@
+---
+title: Distributing my binaries
+date: 2025-07-18
+tags:
+  - tech
+  - notes
+  - draft
+aliases: [uts-016P]
+source: "https://utensil.github.io/forest/uts-016P/"
+---
+
+- [Repology](https://repology.org/)
+- brew for mac & linux
+    - personal tap repo: see
+        - [Taps (Third-Party Repositories) — Homebrew Documentation](https://docs.brew.sh/Taps)
+        - [Adding Software to Homebrew — Homebrew Documentation](https://docs.brew.sh/Adding-Software-to-Homebrew#writing-the-formula)
+        - `create`, `bottle` in [brew(1)](https://docs.brew.sh/Manpage), also `bump*`
+- Windows or all platforms
+    - Aqua private registery
+        - then supported by mise or maybe more
+        - see [Develop a Registry | aqua](https://aquaproj.github.io/docs/develop-registry/)

--- a/content/posts/2025-07-18-using-zig-to-build-more.md
+++ b/content/posts/2025-07-18-using-zig-to-build-more.md
@@ -1,0 +1,28 @@
+---
+title: Using Zig to build more
+date: 2025-07-18
+tags:
+  - tech
+  - notes
+  - draft
+aliases: [uts-016O]
+source: "https://utensil.github.io/forest/uts-016O/"
+---
+
+- C/C++ projects
+    - [All Your Codebase | Loris Cro's Blog](https://kristoff.it/blog/all-your-codebase/)
+        - [All Your Codebase](https://github.com/allyourcodebase)
+            - no GiNaC yet
+- help rust to cross-compile
+    - [rust-cross/cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild)
+        - Compile Cargo project with zig as linker for easier cross compiling
+- help PyPI to store less
+    - [The Python Package Index Should Get Rid Of Its Training Wheels | Loris Cro's Blog](https://kristoff.it/blog/python-training-wheels/)
+    - zig is also available as a PyPI package
+        - [ziglang · PyPI](https://github.com/ziglang/zig-pypi)
+- zig alternative to [PyO3/maturin: Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages](https://github.com/PyO3/maturin)
+    - [spiraldb/ziggy-pydust: A toolkit for building Python extensions in Zig.](https://github.com/spiraldb/ziggy-pydust)
+        - [the orginal template that ueses poetry](https://github.com/spiraldb/ziggy-pydust-template)
+        - [the community template that uses uv and hatchling](https://github.com/erik-dunteman/ziggy-pydust-template)
+            - where hatchling seems to be a better build backend than setup tools post 3.12 for projects with native extensions and custom build hooks
+            - see also [Why Hatch? - Hatch](https://hatch.pypa.io/latest/why/)


### PR DESCRIPTION
## Summary
- Merge the 11 ported posts from PR #26 (originally merged into `main`) into the default branch `v4`
- Posts cover topics from fragmented learning to distributing binaries, dated 2025-03-28 → 2025-07-18

## Context
PR #26 was accidentally merged into `main` instead of the default branch `v4`. This PR brings those commits into `v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)