### PR TITLE
chore: second-pass tags for 28 remaining interest nodes

### DIFF
--- a/content/interests/add-blogs-for-latest-poems.md
+++ b/content/interests/add-blogs-for-latest-poems.md
@@ -1,7 +1,7 @@
 ---
 title: "Add blogs for latest poems"
 date: 2015-04-23
-tags: [interest, creative, poem]
+tags: [interest, creative]
 aliases: [uts-0111]
 source: "https://utensil.github.io/forest/uts-0111/"
 ---

--- a/content/interests/add-proof-of-concept-implementations.md
+++ b/content/interests/add-proof-of-concept-implementations.md
@@ -1,7 +1,7 @@
 ---
 title: "Add proof-of-concept implementations"
 date: 2015-04-08
-tags: [interest, devtools]
+tags: [interest, tooling]
 aliases: [uts-0125]
 source: "https://utensil.github.io/forest/uts-0125/"
 ---

--- a/content/interests/experiment-with-saguijssagui.md
+++ b/content/interests/experiment-with-saguijssagui.md
@@ -1,7 +1,7 @@
 ---
 title: "Experiment with saguijs/sagui"
 date: 2016-07-06
-tags: [interest, webdev, devtools]
+tags: [interest, web, tooling]
 aliases: [uts-0068]
 source: "https://utensil.github.io/forest/uts-0068/"
 ---

--- a/content/interests/find-good-screen-record-software.md
+++ b/content/interests/find-good-screen-record-software.md
@@ -1,7 +1,7 @@
 ---
 title: "Find good screen record software"
 date: 2016-04-08
-tags: [interest, media, devtools]
+tags: [interest, media, tooling]
 aliases: [uts-0102]
 source: "https://utensil.github.io/forest/uts-0102/"
 ---

--- a/content/interests/investigate-fonts.md
+++ b/content/interests/investigate-fonts.md
@@ -1,7 +1,7 @@
 ---
 title: "Investigate fonts"
 date: 2015-02-14
-tags: [interest, webdev]
+tags: [interest, web]
 aliases: [uts-0137]
 source: "https://utensil.github.io/forest/uts-0137/"
 ---

--- a/content/interests/investigate-neural-darwinism-and-reentry.md
+++ b/content/interests/investigate-neural-darwinism-and-reentry.md
@@ -1,7 +1,7 @@
 ---
 title: "Investigate Neural Darwinism and Reentry"
 date: 2014-10-22
-tags: [interest, bio]
+tags: [interest, sci]
 aliases: [uts-0146]
 source: "https://utensil.github.io/forest/uts-0146/"
 ---

--- a/content/interests/investigate-stamplay.md
+++ b/content/interests/investigate-stamplay.md
@@ -1,7 +1,7 @@
 ---
 title: "Investigate Stamplay"
 date: 2015-04-23
-tags: [interest, webdev]
+tags: [interest, web]
 aliases: [uts-0110]
 source: "https://utensil.github.io/forest/uts-0110/"
 ---

--- a/content/interests/investigate-the-neurobiology-of-dreaming.md
+++ b/content/interests/investigate-the-neurobiology-of-dreaming.md
@@ -1,7 +1,7 @@
 ---
 title: "Investigate the neurobiology of dreaming"
 date: 2016-06-10
-tags: [interest, bio]
+tags: [interest, sci]
 aliases: [uts-0074]
 source: "https://utensil.github.io/forest/uts-0074/"
 ---

--- a/content/interests/js-ecosystem-presentation.md
+++ b/content/interests/js-ecosystem-presentation.md
@@ -1,7 +1,7 @@
 ---
 title: "Presentation about js ecosystem based on kuitos/kuitos.github.io/issues/32"
 date: 2015-12-29
-tags: [interest, webdev, essay]
+tags: [interest, web, essay]
 aliases: [uts-0107]
 source: "https://utensil.github.io/forest/uts-0107/"
 ---

--- a/content/interests/proofreading-tools.md
+++ b/content/interests/proofreading-tools.md
@@ -1,7 +1,7 @@
 ---
 title: "Proofreading tools"
 date: 2016-05-11
-tags: [interest, lang, devtools]
+tags: [interest, lang, tooling]
 aliases: [uts-0090]
 source: "https://utensil.github.io/forest/uts-0090/"
 ---

--- a/content/tag-system.md
+++ b/content/tag-system.md
@@ -3,13 +3,29 @@ title: Tag system
 tag: meta
 ---
 
-In this note, I would like write down my thoughts on designing my tag system.
+The tag system used in this garden originates from my [forest learning diary](https://utensil.github.io/forest/uts-0018/), where I developed a lightweight hashtag vocabulary to categorize notes by topic.
+
+## Tags
+
+**Languages & systems:** #rust, #zig, #py, #lang, #cpp, #linux
+
+**AI & models:** #agent, #lm, #mm
+
+**Math & science:** #math, #formal, #lean, #ph, #sci
+
+**Graphics & visual:** #cg, #gpu, #shader, #diagram
+
+**Tools & workflow:** #tooling, #tui, #typst, #kb, #jj, #helix
+
+**Web & network:** #web, #openweb, #fediverse, #selfhost, #sec
+
+**Observability:** #chaos, #disect
+
+**Content types:** #interest, #post, #essay, #draft
+
+**Other:** #creative, #media, #personal
+
+## Inspiration
 
 This is initially inspired that lobste.rs has [a tag system for filtering](https://lobste.rs/filters), and Simon Willison’s Weblog has [a rich tag system](https://simonwillison.net/tags/).
-
-For now, I just have the following examples:
-
-- #post
-- #im
-- #selfhost
 


### PR DESCRIPTION
## Summary
- Second-pass tagging for 28 interest nodes that were left as `[interest]` only in the first pass
- All 136 interests now have topic tags
- Updated tag-system page with tag origin and full vocabulary
- Renamed `devtools` → `tooling` (17 files) and `tui` (1 file: neovim)
- Renamed `bio` → `sci`, `webdev` → `web`, merged `poem` into `creative`

## New tags added
| Tag | Description | Files |
|-----|-------------|-------|
| `creative` | Poetry, arts, literature, writing | 7 |
| `personal` | Personal organization, habits, identity | 4 |
| `media` | Audio/video tools, screen recording | 3 |
| `web` | JS ecosystem, web frameworks | 4 |
| `sci` | Neuroscience, biology | 2 |

## Tag renames
- `devtools` → `tooling` / `tui`
- `bio` → `sci`
- `webdev` → `web`
- `poem` merged into `creative`

## Merge order
This PR should be merged **before** PR #28 (reclassify notes).

## Test plan
- [ ] Verify `npx quartz build` succeeds
- [ ] Check tag-system page renders correctly
- [ ] Spot-check tag accuracy on a few files

🤖 Generated with [Claude Code](https://claude.com/claude-code)