### PR TITLE
feat(interest): add Physics notes reading list [AGENT]

### DIFF
--- a/content/interests/physics-notes.md
+++ b/content/interests/physics-notes.md
@@ -1,0 +1,13 @@
+---
+title: "Physics notes"
+date: 2026-07-10
+tags: [interest, ph]
+---
+
+Some good physics reading, found via [napkin issue #194](https://github.com/vEnhance/napkin/issues/194).
+
+- [Kevin Zhou](https://knzhou.github.io/), physics olympiad handouts and problem sets, plus graduate notes.
+- [John McGreevy](https://mcgreevy.physics.ucsd.edu/), UCSD course notes, heavy on QFT and many-body.
+- [David Tong](https://davidtong.org/teaching/), the classic Cambridge lecture notes covering most of the syllabus.
+- [No-Nonsense Books](https://nononsensebooks.com/#books), Jakob Schwichtenberg's gentle intros to classical mechanics, QFT and the like.
+- [cPhysics](https://www.cphysics.org/), a free, self-contained reference built as cross-linked articles.


### PR DESCRIPTION
Adds a `physics-notes` interest under `content/interests/`, capturing good physics reading (Kevin Zhou, McGreevy, David Tong, No-Nonsense Books, cPhysics) from vEnhance/napkin#194. Tagged `[interest, ph]` per the current convention.

Landing via PR since `main` blocks direct pushes.